### PR TITLE
Migrate to tcell/v3 color package and update color usage

### DIFF
--- a/examples/boxes.go
+++ b/examples/boxes.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/gdamore/tcell/v3"
+	"github.com/gdamore/tcell/v3/color"
 	"github.com/noborus/tcellansi"
 )
 
@@ -48,7 +49,7 @@ func makebox(s tcell.Screen) {
 		rgb := tcell.NewHexColor(int32(rand.Int() & 0xffffff))
 		st = st.Background(rgb)
 	} else if s.Colors() > 1 {
-		st = st.Background(tcell.Color(rand.Int()%s.Colors()) | tcell.ColorValid)
+		st = st.Background(color.Color(rand.Int()%s.Colors()) | color.IsValid)
 	} else {
 		st = st.Reverse(rand.Int()%2 == 0)
 		gl = glyphs[rand.Int()%len(glyphs)]
@@ -84,8 +85,8 @@ func main() {
 	}
 	/*
 		s.SetStyle(tcell.StyleDefault.
-			Foreground(tcell.ColorBlack).
-			Background(tcell.ColorWhite))
+			Foreground(color.Black).
+			Background(color.White))
 	*/
 	s.Clear()
 

--- a/examples/fullcolor.go
+++ b/examples/fullcolor.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/gdamore/tcell/v3"
+	"github.com/gdamore/tcell/v3/color"
 	"github.com/noborus/tcellansi"
 )
 
@@ -25,14 +26,14 @@ func drawColorGrid(s tcell.Screen) {
 	// System colors (0..15)
 	for y := 0; y < 2; y++ {
 		for x := 0; x < 8; x++ {
-			style := tcell.StyleDefault.Background(tcell.ColorValid + tcell.Color(x+y*8))
+			style := tcell.StyleDefault.Background(color.IsValid + color.Color(x+y*8))
 			s.SetContent(x*2, y, ' ', nil, style)
 			s.SetContent(x*2+1, y, ' ', nil, style)
 		}
 	}
 
 	// Color cube (16..231)
-	idx := tcell.ColorWhite + 1
+	idx := color.White + 1
 	for r := 0; r < 6; r++ {
 		for g := 0; g < 6; g++ {
 			x := r * 7
@@ -49,7 +50,7 @@ func drawColorGrid(s tcell.Screen) {
 
 	// Grayscale ramp (232..255)
 	for i := 232; i < 256; i++ {
-		style := tcell.StyleDefault.Background(tcell.ColorValid + tcell.Color(i))
+		style := tcell.StyleDefault.Background(color.IsValid + color.Color(i))
 		s.SetContent((i-232)*2, 12, ' ', nil, style)
 		s.SetContent((i-232)*2+1, 12, ' ', nil, style)
 	}

--- a/examples/hello.go
+++ b/examples/hello.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"github.com/gdamore/tcell/v3"
+	"github.com/gdamore/tcell/v3/color"
 	"github.com/noborus/tcellansi"
 )
 
@@ -14,7 +15,7 @@ func main() {
 	screen.Init()
 
 	// Create a style
-	style := tcell.StyleDefault.Foreground(tcell.ColorRed).Background(tcell.ColorBlack)
+	style := tcell.StyleDefault.Foreground(color.Red).Background(color.Black)
 
 	// Convert the style to ANSI escape sequence
 	ansiSeq := tcellansi.ToAnsi(style)

--- a/examples/mouse.go
+++ b/examples/mouse.go
@@ -27,6 +27,7 @@ import (
 	"runtime"
 
 	"github.com/gdamore/tcell/v3"
+	"github.com/gdamore/tcell/v3/color"
 	"github.com/noborus/tcellansi"
 )
 
@@ -110,8 +111,8 @@ func main() {
 
 	s.SetTitle("Tcell Mouse Demonstration")
 	defStyle = tcell.StyleDefault.
-		Background(tcell.ColorReset).
-		Foreground(tcell.ColorReset)
+		Background(color.Reset).
+		Foreground(color.Reset)
 	s.SetStyle(defStyle)
 	s.EnableMouse()
 	s.EnablePaste()
@@ -124,7 +125,7 @@ func main() {
 	pastefmt := "Paste: [%d] %s"
 	focusfmt := "Focus: %s"
 	style := tcell.StyleDefault.
-		Foreground(tcell.ColorMidnightBlue).Background(tcell.ColorLightCoral)
+		Foreground(color.MidnightBlue).Background(color.LightCoral)
 
 	mx, my := -1, -1
 	ox, oy := -1, -1
@@ -161,10 +162,10 @@ loop:
 		s.Show()
 		bstr = ""
 		ev := <-s.EventQ()
-		st := tcell.StyleDefault.Background(tcell.ColorRed)
+		st := tcell.StyleDefault.Background(color.Red)
 		up := tcell.StyleDefault.
-			Background(tcell.ColorBlue).
-			Foreground(tcell.ColorBlack)
+			Background(color.Blue).
+			Foreground(color.Black)
 		w, h = s.Size()
 
 		// always clear any old selection box
@@ -266,21 +267,21 @@ loop:
 			if button != tcell.ButtonNone && ox < 0 {
 				ox, oy = x, y
 			}
-			theme := []tcell.Color{
-				tcell.ColorGray,
-				tcell.ColorRed,
-				tcell.ColorLime,
-				tcell.ColorYellow,
-				tcell.ColorFuchsia,
-				tcell.ColorBlue,
-				tcell.ColorAqua,
-				tcell.ColorSilver,
+			theme := []color.Color{
+				color.Gray,
+				color.Red,
+				color.Lime,
+				color.Yellow,
+				color.Fuchsia,
+				color.Blue,
+				color.Aqua,
+				color.Silver,
 			}
 			switch ev.Buttons() {
 			case tcell.ButtonNone:
 				if ox >= 0 {
 					bg := theme[lchar%8]
-					fg := tcell.ColorBlack
+					fg := color.Black
 					drawBox(s, ox, oy, x, y,
 						up.Background(bg).Foreground(fg),
 						lchar)

--- a/examples/simple.go
+++ b/examples/simple.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gdamore/tcell/v3"
+	"github.com/gdamore/tcell/v3/color"
 	"github.com/noborus/tcellansi"
 )
 
@@ -17,7 +18,7 @@ func main() {
 	screen.Init()
 
 	// Create a style
-	style := tcell.StyleDefault.Background(tcell.ColorBlue).Underline(true).Underline(tcell.ColorGreen).Underline(tcell.UnderlineStyleDouble)
+	style := tcell.StyleDefault.Background(color.Blue).Underline(true).Underline(color.Green).Underline(tcell.UnderlineStyleDouble)
 
 	screen.PutStrStyled(0, 0, "Hello world!█", style)
 

--- a/examples/underline.go
+++ b/examples/underline.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/gdamore/tcell/v3"
+	"github.com/gdamore/tcell/v3/color"
 	"github.com/noborus/tcellansi"
 )
 
@@ -26,7 +27,7 @@ func main() {
 		}
 	}()
 	// title
-	titleStyle := tcell.StyleDefault.Foreground(tcell.ColorWhite).Bold(true)
+	titleStyle := tcell.StyleDefault.Foreground(color.White).Bold(true)
 	screen.PutStrStyled(0, 0, "UnderlineColor Examples (Press ESC to exit)", titleStyle)
 
 	// Underline examples
@@ -39,48 +40,48 @@ func main() {
 		{
 			y:    2,
 			text: "Solid Red Underline",
-			style: tcell.StyleDefault.Foreground(tcell.ColorWhite).
-				Underline(tcell.UnderlineStyleSolid, tcell.ColorRed),
+			style: tcell.StyleDefault.Foreground(color.White).
+				Underline(tcell.UnderlineStyleSolid, color.Red),
 			desc: "Style: Solid, Color: Red",
 		},
 		{
 			y:    4,
 			text: "Double Blue Underline",
-			style: tcell.StyleDefault.Foreground(tcell.ColorWhite).
-				Underline(tcell.UnderlineStyleDouble, tcell.ColorBlue),
+			style: tcell.StyleDefault.Foreground(color.White).
+				Underline(tcell.UnderlineStyleDouble, color.Blue),
 			desc: "Style: Double, Color: Blue",
 		},
 		{
 			y:    6,
 			text: "Curly Green Underline",
-			style: tcell.StyleDefault.Foreground(tcell.ColorWhite).
-				Underline(tcell.UnderlineStyleCurly, tcell.ColorGreen),
+			style: tcell.StyleDefault.Foreground(color.White).
+				Underline(tcell.UnderlineStyleCurly, color.Green),
 			desc: "Style: Curly, Color: Green",
 		},
 		{
 			y:    8,
 			text: "Dotted Yellow Underline",
-			style: tcell.StyleDefault.Foreground(tcell.ColorWhite).
-				Underline(tcell.UnderlineStyleDotted, tcell.ColorYellow),
+			style: tcell.StyleDefault.Foreground(color.White).
+				Underline(tcell.UnderlineStyleDotted, color.Yellow),
 			desc: "Style: Dotted, Color: Yellow",
 		},
 		{
 			y:    10,
 			text: "Dashed Magenta Underline",
-			style: tcell.StyleDefault.Foreground(tcell.ColorWhite).
+			style: tcell.StyleDefault.Foreground(color.White).
 				Underline(tcell.UnderlineStyleDashed, tcell.NewRGBColor(139, 0, 139)),
 			desc: "Style: Dashed, Color: Magenta",
 		},
 		{
 			y:    12,
 			text: "Custom RGB Orange Curly Underline",
-			style: tcell.StyleDefault.Foreground(tcell.ColorWhite).
+			style: tcell.StyleDefault.Foreground(color.White).
 				Underline(tcell.UnderlineStyleCurly, tcell.NewRGBColor(255, 165, 0)),
 			desc: "",
 		},
 	}
 
-	descStyle := tcell.StyleDefault.Foreground(tcell.ColorGray)
+	descStyle := tcell.StyleDefault.Foreground(color.Gray)
 	for _, ex := range examples {
 		screen.PutStrStyled(0, ex.y, ex.text, ex.style)
 		if ex.desc != "" {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 toolchain go1.24.2
 
-require github.com/gdamore/tcell/v3 v3.0.3
+require github.com/gdamore/tcell/v3 v3.0.6
 
 require (
 	github.com/gdamore/encoding v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/gdamore/encoding v1.0.1 h1:YzKZckdBL6jVt2Gc+5p82qhrGiqMdG/eNs6Wy0u3Uhw=
 github.com/gdamore/encoding v1.0.1/go.mod h1:0Z0cMFinngz9kS1QfMjCP8TY7em3bZYeeklsSDPivEo=
-github.com/gdamore/tcell/v3 v3.0.5 h1:odOxRkUnMNFN0+kbx2bW7SxBAVUgAwVCVRwMJ92gzxE=
-github.com/gdamore/tcell/v3 v3.0.5/go.mod h1:hPfjyFARu5K9vLzjN5TrYAoK/D9dZmqRbQkevGvK7oQ=
 github.com/gdamore/tcell/v3 v3.0.6 h1:T9vLs5AcVJWkKvKAQmJ3rv6K3uUvctErb+y4J3igUbI=
 github.com/gdamore/tcell/v3 v3.0.6/go.mod h1:hPfjyFARu5K9vLzjN5TrYAoK/D9dZmqRbQkevGvK7oQ=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,9 @@
 github.com/gdamore/encoding v1.0.1 h1:YzKZckdBL6jVt2Gc+5p82qhrGiqMdG/eNs6Wy0u3Uhw=
 github.com/gdamore/encoding v1.0.1/go.mod h1:0Z0cMFinngz9kS1QfMjCP8TY7em3bZYeeklsSDPivEo=
-github.com/gdamore/tcell/v3 v3.0.3 h1:1xsLaoW75MIsZbIClW0lj7DzBq4OBzNufAKHteQP6tE=
-github.com/gdamore/tcell/v3 v3.0.3/go.mod h1:hPfjyFARu5K9vLzjN5TrYAoK/D9dZmqRbQkevGvK7oQ=
+github.com/gdamore/tcell/v3 v3.0.5 h1:odOxRkUnMNFN0+kbx2bW7SxBAVUgAwVCVRwMJ92gzxE=
+github.com/gdamore/tcell/v3 v3.0.5/go.mod h1:hPfjyFARu5K9vLzjN5TrYAoK/D9dZmqRbQkevGvK7oQ=
+github.com/gdamore/tcell/v3 v3.0.6 h1:T9vLs5AcVJWkKvKAQmJ3rv6K3uUvctErb+y4J3igUbI=
+github.com/gdamore/tcell/v3 v3.0.6/go.mod h1:hPfjyFARu5K9vLzjN5TrYAoK/D9dZmqRbQkevGvK7oQ=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=

--- a/toansi.go
+++ b/toansi.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/gdamore/tcell/v3"
+	"github.com/gdamore/tcell/v3/color"
 )
 
 // ToAnsi converts the tcell style to an ANSI escape sequence.
@@ -24,13 +25,13 @@ func ToAnsi(style tcell.Style) string {
 	bg := style.GetBackground()
 
 	// Foreground color
-	if fg != tcell.ColorDefault {
+	if fg != color.Default {
 		ansi.WriteString("\x1b[")
 		ansi.WriteString(foregroundColorToAnsi(fg))
 		ansi.WriteString("m")
 	}
 	// Background color
-	if bg != tcell.ColorDefault {
+	if bg != color.Default {
 		ansi.WriteString("\x1b[")
 		ansi.WriteString(backgroundColorToAnsi(bg))
 		ansi.WriteString("m")
@@ -61,33 +62,33 @@ func ToAnsi(style tcell.Style) string {
 }
 
 // foregroundColorToAnsi converts the foreground color to an ANSI escape sequence.
-func foregroundColorToAnsi(fg tcell.Color) string {
-	if fg > tcell.ColorWhite {
+func foregroundColorToAnsi(fg color.Color) string {
+	if fg > color.White {
 		return "38;" + colorToAnsi(fg, ";")
 	}
-	if (fg - tcell.ColorValid) < 8 {
-		return strconv.Itoa(int(30 + (fg - tcell.ColorValid)))
+	if (fg - color.IsValid) < 8 {
+		return strconv.Itoa(int(30 + (fg - color.IsValid)))
 	}
-	return strconv.Itoa(int(82 + (fg - tcell.ColorValid)))
+	return strconv.Itoa(int(82 + (fg - color.IsValid)))
 }
 
 // backgroundColorToAnsi converts the background color to an ANSI escape sequence.
-func backgroundColorToAnsi(bg tcell.Color) string {
-	if bg > tcell.ColorWhite {
+func backgroundColorToAnsi(bg color.Color) string {
+	if bg > color.White {
 		return "48;" + colorToAnsi(bg, ";")
 	}
-	if (bg - tcell.ColorValid) < 8 {
-		return strconv.Itoa(int(40 + (bg - tcell.ColorValid)))
+	if (bg - color.IsValid) < 8 {
+		return strconv.Itoa(int(40 + (bg - color.IsValid)))
 	}
-	return strconv.Itoa(int(92 + (bg - tcell.ColorValid)))
+	return strconv.Itoa(int(92 + (bg - color.IsValid)))
 }
 
-// colorToAnsi converts the tcell.Color to an ANSI escape sequence.
-func colorToAnsi(color tcell.Color, delm string) string {
-	if color&tcell.ColorIsRGB == 0 {
-		return fmt.Sprintf("5%s%d", delm, color&^tcell.ColorValid)
+// colorToAnsi converts the color.Color to an ANSI escape sequence.
+func colorToAnsi(textColor color.Color, delm string) string {
+	if textColor&color.IsRGB == 0 {
+		return fmt.Sprintf("5%s%d", delm, textColor&^color.IsValid)
 	}
-	r, g, b := color.RGB()
+	r, g, b := textColor.RGB()
 	return fmt.Sprintf("2%s%d%s%d%s%d", delm, r, delm, g, delm, b)
 }
 
@@ -98,7 +99,7 @@ func underlineToAnsi(style tcell.Style) string {
 	us := getUnderlineStyle(style)
 	ansi.WriteString(underlineStyleToAnsi(us))
 	uc := getUnderlineColor(style)
-	if uc != tcell.ColorDefault {
+	if uc != color.Default {
 		ansi.WriteString("\x1b[58:")
 		ansi.WriteString(colorToAnsi(uc, ":"))
 		ansi.WriteString("m")
@@ -128,18 +129,18 @@ func getUnderlineStyle(style tcell.Style) tcell.UnderlineStyle {
 // This is a temporary function to retrieve the underline color using reflection.
 // It assumes that the tcell.Style type has a method named "UnderlineColor".
 // Once tcell officially supports UnderlineColor, this function should be replaced.
-func getUnderlineColor(style tcell.Style) tcell.Color {
+func getUnderlineColor(style tcell.Style) color.Color {
 	v := reflect.ValueOf(style)
 	m := v.MethodByName("GetUnderlineColor")
 	if m.IsValid() {
 		results := m.Call(nil)
 		if len(results) == 1 {
-			if uc, ok := results[0].Interface().(tcell.Color); ok {
+			if uc, ok := results[0].Interface().(color.Color); ok {
 				return uc
 			}
 		}
 	}
-	return tcell.ColorDefault
+	return color.Default
 }
 
 // underlineStyleToAnsi converts the tcell.UnderlineStyle to an ANSI escape sequence.

--- a/toansi_test.go
+++ b/toansi_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/gdamore/tcell/v3"
+	"github.com/gdamore/tcell/v3/color"
 )
 
 func TestToAnsi(t *testing.T) {
@@ -19,12 +20,12 @@ func TestToAnsi(t *testing.T) {
 		},
 		{
 			name:  "foreground color",
-			style: tcell.StyleDefault.Foreground(tcell.ColorRed),
+			style: tcell.StyleDefault.Foreground(color.Red),
 			want:  "\x1b[91m", // palette color processing
 		},
 		{
 			name:  "foreground color256",
-			style: tcell.StyleDefault.Foreground(tcell.Color250),
+			style: tcell.StyleDefault.Foreground(color.Color(250)),
 			want:  "\x1b[38;5;250m", // updated palette color processing
 		},
 		{
@@ -34,7 +35,7 @@ func TestToAnsi(t *testing.T) {
 		},
 		{
 			name:  "background color",
-			style: tcell.StyleDefault.Background(tcell.ColorBlue),
+			style: tcell.StyleDefault.Background(color.Blue),
 			want:  "\x1b[104m", // palette color processing
 		},
 		{
@@ -79,7 +80,7 @@ func TestToAnsi(t *testing.T) {
 		},
 		{
 			name:  "combined attributes",
-			style: tcell.StyleDefault.Foreground(tcell.ColorGreen).Background(tcell.ColorYellow).Bold(true).Underline(true),
+			style: tcell.StyleDefault.Foreground(color.Green).Background(color.Yellow).Bold(true).Underline(true),
 			want:  "\x1b[32m\x1b[103m\x1b[1m\x1b[4m", // palette color, palette color, bold, underline
 		},
 	}
@@ -132,7 +133,7 @@ func TestScreenContentToStrings(t *testing.T) {
 			screen: func() tcell.Screen {
 				s := tcell.NewSimulationScreen("")
 				s.Init()
-				s.SetContent(0, 0, 'A', nil, tcell.StyleDefault.Foreground(tcell.ColorRed))
+				s.SetContent(0, 0, 'A', nil, tcell.StyleDefault.Foreground(color.Red))
 				s.SetContent(1, 0, ' ', nil, tcell.StyleDefault)
 				s.SetContent(2, 0, ' ', nil, tcell.StyleDefault)
 				return s
@@ -145,9 +146,9 @@ func TestScreenContentToStrings(t *testing.T) {
 			screen: func() tcell.Screen {
 				s := tcell.NewSimulationScreen("")
 				s.Init()
-				s.SetContent(0, 0, 'A', nil, tcell.StyleDefault.Foreground(tcell.ColorRed))
-				s.SetContent(1, 0, ' ', nil, tcell.StyleDefault.Background(tcell.ColorBlue))
-				s.SetContent(2, 0, ' ', nil, tcell.StyleDefault.Background(tcell.ColorBlue))
+				s.SetContent(0, 0, 'A', nil, tcell.StyleDefault.Foreground(color.Red))
+				s.SetContent(1, 0, ' ', nil, tcell.StyleDefault.Background(color.Blue))
+				s.SetContent(2, 0, ' ', nil, tcell.StyleDefault.Background(color.Blue))
 				return s
 			}(),
 			x1: 0, x2: 3, y1: 0, y2: 1,
@@ -158,8 +159,8 @@ func TestScreenContentToStrings(t *testing.T) {
 			screen: func() tcell.Screen {
 				s := tcell.NewSimulationScreen("")
 				s.Init()
-				s.SetContent(0, 0, 'A', nil, tcell.StyleDefault.Foreground(tcell.ColorRed))
-				s.SetContent(1, 0, 'B', nil, tcell.StyleDefault.Background(tcell.ColorBlue))
+				s.SetContent(0, 0, 'A', nil, tcell.StyleDefault.Foreground(color.Red))
+				s.SetContent(1, 0, 'B', nil, tcell.StyleDefault.Background(color.Blue))
 				s.SetContent(0, 1, 'C', nil, tcell.StyleDefault.Bold(true))
 				return s
 			}(),
@@ -185,7 +186,7 @@ func TestScreenContentToStrings(t *testing.T) {
 			screen: func() tcell.Screen {
 				s := tcell.NewSimulationScreen("")
 				s.Init()
-				s.SetContent(0, 0, 'A', []rune{'\u0301'}, tcell.StyleDefault.Foreground(tcell.ColorRed))
+				s.SetContent(0, 0, 'A', []rune{'\u0301'}, tcell.StyleDefault.Foreground(color.Red))
 				return s
 			}(),
 			x1: 0, x2: 2, y1: 0, y2: 1,
@@ -218,7 +219,7 @@ func TestScreenContentToStrings(t *testing.T) {
 			screen: func() tcell.Screen {
 				s := tcell.NewSimulationScreen("")
 				s.Init()
-				SetLineContent(s, 0, "Hello, World!", tcell.StyleDefault.Foreground(tcell.ColorRed))
+				SetLineContent(s, 0, "Hello, World!", tcell.StyleDefault.Foreground(color.Red))
 				return s
 			}(),
 			x1: 0, x2: 13, y1: 0, y2: 1,
@@ -229,7 +230,7 @@ func TestScreenContentToStrings(t *testing.T) {
 			screen: func() tcell.Screen {
 				s := tcell.NewSimulationScreen("")
 				s.Init()
-				SetLineContent(s, 0, "1234567890123456789012345678901234567890123456789012345678901234567890123456789あ", tcell.StyleDefault.Foreground(tcell.ColorRed))
+				SetLineContent(s, 0, "1234567890123456789012345678901234567890123456789012345678901234567890123456789あ", tcell.StyleDefault.Foreground(color.Red))
 				return s
 			}(),
 			x1: 0, x2: 80, y1: 0, y2: 1,

--- a/toansi_test.go
+++ b/toansi_test.go
@@ -5,7 +5,17 @@ import (
 
 	"github.com/gdamore/tcell/v3"
 	"github.com/gdamore/tcell/v3/color"
+	"github.com/gdamore/tcell/v3/mock"
 )
+
+func newMockScreen(t *testing.T) tcell.Screen {
+	mt := mock.NewMockTerm()
+	s, err := tcell.NewTerminfoScreenFromTty(mt)
+	if err != nil {
+		t.Fatalf("Failed to create screen: %v", err)
+	}
+	return s
+}
 
 func TestToAnsi(t *testing.T) {
 	tests := []struct {
@@ -25,7 +35,7 @@ func TestToAnsi(t *testing.T) {
 		},
 		{
 			name:  "foreground color256",
-			style: tcell.StyleDefault.Foreground(color.Color(250)),
+			style: tcell.StyleDefault.Foreground(color.XTerm250),
 			want:  "\x1b[38;5;250m", // updated palette color processing
 		},
 		{
@@ -88,7 +98,7 @@ func TestToAnsi(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := ToAnsi(tt.style); got != tt.want {
-				t.Errorf("StyleToES() = %v, want %v", got, tt.want)
+				t.Errorf("StyleToES() = %#v, want %#v", got, tt.want)
 			}
 		})
 	}
@@ -111,7 +121,7 @@ func TestScreenContentToStrings(t *testing.T) {
 		{
 			name: "empty screen",
 			screen: func() tcell.Screen {
-				s := tcell.NewSimulationScreen("")
+				s := newMockScreen(t)
 				s.Init()
 				return s
 			}(),
@@ -131,7 +141,7 @@ func TestScreenContentToStrings(t *testing.T) {
 		{
 			name: "single cell",
 			screen: func() tcell.Screen {
-				s := tcell.NewSimulationScreen("")
+				s := newMockScreen(t)
 				s.Init()
 				s.SetContent(0, 0, 'A', nil, tcell.StyleDefault.Foreground(color.Red))
 				s.SetContent(1, 0, ' ', nil, tcell.StyleDefault)
@@ -144,7 +154,7 @@ func TestScreenContentToStrings(t *testing.T) {
 		{
 			name: "single cell2",
 			screen: func() tcell.Screen {
-				s := tcell.NewSimulationScreen("")
+				s := newMockScreen(t)
 				s.Init()
 				s.SetContent(0, 0, 'A', nil, tcell.StyleDefault.Foreground(color.Red))
 				s.SetContent(1, 0, ' ', nil, tcell.StyleDefault.Background(color.Blue))
@@ -157,7 +167,7 @@ func TestScreenContentToStrings(t *testing.T) {
 		{
 			name: "multiple cells",
 			screen: func() tcell.Screen {
-				s := tcell.NewSimulationScreen("")
+				s := newMockScreen(t)
 				s.Init()
 				s.SetContent(0, 0, 'A', nil, tcell.StyleDefault.Foreground(color.Red))
 				s.SetContent(1, 0, 'B', nil, tcell.StyleDefault.Background(color.Blue))
@@ -173,7 +183,7 @@ func TestScreenContentToStrings(t *testing.T) {
 		{
 			name: "wide character",
 			screen: func() tcell.Screen {
-				s := tcell.NewSimulationScreen("")
+				s := newMockScreen(t)
 				s.Init()
 				s.SetContent(0, 0, '亜', nil, tcell.StyleDefault)
 				return s
@@ -184,7 +194,7 @@ func TestScreenContentToStrings(t *testing.T) {
 		{
 			name: "combc characters",
 			screen: func() tcell.Screen {
-				s := tcell.NewSimulationScreen("")
+				s := newMockScreen(t)
 				s.Init()
 				s.SetContent(0, 0, 'A', []rune{'\u0301'}, tcell.StyleDefault.Foreground(color.Red))
 				return s
@@ -195,7 +205,7 @@ func TestScreenContentToStrings(t *testing.T) {
 		{
 			name: "underlineStyle",
 			screen: func() tcell.Screen {
-				s := tcell.NewSimulationScreen("")
+				s := newMockScreen(t)
 				s.Init()
 				s.SetContent(0, 0, 'A', nil, tcell.StyleDefault.Underline(true).Underline(tcell.UnderlineStyleCurly))
 				return s
@@ -206,7 +216,7 @@ func TestScreenContentToStrings(t *testing.T) {
 		{
 			name: "underlineColor",
 			screen: func() tcell.Screen {
-				s := tcell.NewSimulationScreen("")
+				s := newMockScreen(t)
 				s.Init()
 				s.SetContent(0, 0, 'A', nil, tcell.StyleDefault.Underline(true).Underline(tcell.GetColor("#00FF00")))
 				return s
@@ -217,7 +227,7 @@ func TestScreenContentToStrings(t *testing.T) {
 		{
 			name: "single line",
 			screen: func() tcell.Screen {
-				s := tcell.NewSimulationScreen("")
+				s := newMockScreen(t)
 				s.Init()
 				SetLineContent(s, 0, "Hello, World!", tcell.StyleDefault.Foreground(color.Red))
 				return s
@@ -228,7 +238,7 @@ func TestScreenContentToStrings(t *testing.T) {
 		{
 			name: "over line",
 			screen: func() tcell.Screen {
-				s := tcell.NewSimulationScreen("")
+				s := newMockScreen(t)
 				s.Init()
 				SetLineContent(s, 0, "1234567890123456789012345678901234567890123456789012345678901234567890123456789あ", tcell.StyleDefault.Foreground(color.Red))
 				return s


### PR DESCRIPTION
Refactored all examples and main code to use tcell/v3/color instead of direct tcell color constants.
Updated style and color handling in all example files for compatibility with the new color package.
Modified toansi.go and related functions to use the new color types and methods.
Updated dependencies: bumped tcell/v3 from v3.0.3 to v3.0.6 in go.mod and go.sum.
Adjusted tests to use the new color package.